### PR TITLE
Switch to UBI9 Micro

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: registry.access.redhat.com/ubi9/ubi-micro:9.4


### PR DESCRIPTION
Use ubi9/ubi-micro as the default image, which has IBM Power and Z architecture support.

This is for ko only - the Containerfile already uses UBI Micro.